### PR TITLE
Add GitHub Actions workflow for automatic Docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Push Data Collector
 
 on:
   push:
-    branches: [main]
+    branches: [main, feature/github-actions]
     paths:
       - '**'
   workflow_dispatch:
@@ -38,6 +38,9 @@ jobs:
           type=ref,event=branch
           type=sha,prefix=sha-
           type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build and Push Data Collector
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/att-data-collector
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=sha,prefix=sha-
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for building and pushing Docker images to GitHub Container Registry
- Includes Docker Buildx setup for advanced caching features
- Triggers on main branch pushes and manual dispatch

## Changes
- `.github/workflows/build.yml`: Complete CI/CD pipeline for Docker image builds
- Uses `ghcr.io/att-acelerar-e-transformar-o-turismo/att-data-collector` as image name
- Implements GitHub Actions cache for faster builds

## Test Plan
- Workflow triggers correctly on push to main
- Docker image builds successfully
- Image is pushed to GitHub Container Registry
- Production deployment can pull the latest image